### PR TITLE
ci: keep waltz unpublished until the crate name is settled

### DIFF
--- a/waltz/Cargo.toml
+++ b/waltz/Cargo.toml
@@ -7,8 +7,8 @@ license       = { workspace = true }
 readme        = "README.md"
 homepage      = { workspace = true }
 repository    = { workspace = true }
-documentation = "https://docs.rs/waltz/latest/waltz/"
-publish       = true
+documentation = { workspace = true }
+publish       = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Signed-off-by: Heiko Seeberger <git@heikoseeberger.de>
