### PR TITLE
ci: drop tag trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - tellus-v*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Signed-off-by: Heiko Seeberger <git@heikoseeberger.de>
