### PR TITLE
build(deps): bump Rust to 1.98.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.98.0"
+channel = "1.98.1"


### PR DESCRIPTION
Signed-off-by: Heiko Seeberger <git@heikoseeberger.de>
